### PR TITLE
Add custom script for manual hwlat tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # bench-hwlatdetect
+
+Benchmark wrapper for hwlat_detector tracer.
+
+## Documentation
+https://www.kernel.org/doc/html/latest/trace/hwlat_detector.html
+
+## Source
+https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git
+
+## Usage
+To start hwlatdetect with the default python utility, run:
+```
+hwlatdetect-client --duration 60 --threshold 1us
+```
+
+To start hwlatdetect with the manual tracer (without the utility), run:
+```
+hwlatdetect-client --duration 60 --threshold 1us --utility no
+```
+
+To start hwlatdetect with custom cpumask and width, run:
+```
+hwlatdetect-client --duration 60 --threshold 1us --utility no --width 950000 --cpumask ff,ffffffcf,fffffffc
+```
+Note: cpumask and width are not currently supported by the utility.
+
+
+

--- a/hwlatdetect-client
+++ b/hwlatdetect-client
@@ -12,11 +12,16 @@ validate_sw_prereqs
 duration=60
 threshold=1us
 
-longopts="duration:,threshold:"
-opts=$(getopt -q -o "d:t:" --longoptions "$longopts" -n "getopt.sh" -- "$@");
+longopts="duration:,threshold:,width:,cpumask:,utility:"
+opts=$(getopt -q -o "c:d:t:w:u:" --longoptions "$longopts" -n "getopt.sh" -- "$@");
 eval set -- "$opts";
 while true; do
     case "$1" in
+        -c|--cpumask)
+            shift
+            cpumask=$1
+            shift
+            ;;
         -d|--duration)
             shift
             duration=$1
@@ -25,6 +30,16 @@ while true; do
         -t|--threshold)
             shift
             threshold=$1
+            shift
+            ;;
+        -c|--width)
+            shift
+            width=$1
+            shift
+            ;;
+        -u|--utility)
+            shift
+            utility=$1
             shift
             ;;
         --)
@@ -38,6 +53,36 @@ while true; do
 done
 
 cmd="hwlatdetect --duration=${duration} --threshold=${threshold}"
+
+if [ -n ${utility} ]; then
+    echo "utility: $utility"
+    if [ "${utility}" = "no" ]; then
+         echo "Manual tracer mode on: The utility will NOT be used."
+         cpumask_arg=""
+         if [ -n ${cpumask} ]; then
+              cpumask_arg="--cpumask=${cpumask}"
+         fi
+         width_arg=""
+         if [ -n ${width} ]; then
+              width_arg="--cpumask=${width}"
+         fi
+         cmd="manual-hwlatdetect --duration=${duration} --threshold=${threshold} ${cpumask_arg} ${width_arg}"
+    fi
+else
+    utility="yes"
+fi
+
+if [ "${utility}" != "no" ]; then
+     if [ -n ${cpumask} ]; then
+           echo "Error: cpumask is not supported by the utility, set utility=no to run on manual mode."
+           exit 1
+     fi
+     if [ -n ${width} ]; then
+           echo "Error: width is not supported by the utility, set utility=no to run on manual mode."
+           exit 1
+     fi
+fi
+
 echo "About to run: $cmd"
 date +%s.%N >begin.txt
 $cmd >hwlatdetect-bin-stderrout.txt 2>&1

--- a/manual-hwlatdetect
+++ b/manual-hwlatdetect
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+longopts="duration:,threshold:,cpumask:,width:"
+opts=$(getopt -q -o "c:d:t:w:" --longoptions "$longopts" -n "getopt.sh" -- "$@");
+eval set -- "$opts";
+while true; do
+    case "$1" in
+        -c|--cpumask)
+            shift
+            cpumask=$1
+            shift
+            ;;
+        -d|--duration)
+            shift
+            duration=$1
+            shift
+            ;;
+        -t|--threshold)
+            shift
+            threshold=$1
+            shift
+            ;;
+        -c|--width)
+            shift
+            width=$1
+            shift
+            ;;
+        --)
+            shift;
+            break
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+set -eux
+
+# cleanup
+/bin/umount /sys/kernel/debug || true
+
+# mount debugfs
+grep debugfs /proc/mounts
+if [ $? -eq 1 ]; then
+    /bin/mount -t debugfs none /sys/kernel/debug
+fi
+cat /proc/mounts
+
+# reset trace file
+echo > sys/kernel/debug/tracing/trace
+
+# set threshold, minimum latency value to be considered (usecs)
+echo ${threshold} > /sys/kernel/debug/tracing/tracing_thresh
+
+# set width time period to sample with CPUs held (usecs)
+if [ -n $width} ]; then
+    echo ${width} > /sys/kernel/debug/tracing/hwlat_detector/width
+fi
+
+# cpumask
+if [ -n ${cpumask} ]; then
+    echo ${cpumask} > /sys/kernel/debug/tracing/tracing_cpumask
+fi
+
+# set hwlat tracer
+echo hwlat > /sys/kernel/debug/tracing/current_tracer
+
+# start hwlat tracer
+echo 1 > /sys/kernel/debug/tracing/tracing_on
+
+# test duration
+sleep ${duration}
+
+# stop hwlat tracer
+echo 0 > /sys/kernel/debug/tracing/tracing_on
+
+# wait to stop tracer
+sleep 3
+
+# get results from trace file
+cat /sys/kernel/debug/tracing/trace

--- a/manual-hwlatdetect
+++ b/manual-hwlatdetect
@@ -60,6 +60,9 @@ fi
 
 # cpumask
 if [ -n ${cpumask} ]; then
+    if [ "${cpumask}" = "auto" ] || [ "${cpumask}" = "yes" ] || [ "${cpumask}" = "workload" ]; then
+        cpumask=$(${TOOLBOX_HOME}/bin/cpumask.py --cpus ${WORKLOAD_CPUS} | grep hexmask | cut -d'=' -f 2)
+    fi
     echo ${cpumask} > /sys/kernel/debug/tracing/tracing_cpumask
 fi
 


### PR DESCRIPTION
Useful for running tests without the python utility. Some params
like cpumask, width are nott supported by the utility.

To run without the utility, specify utility=no in the multi-value
params file.