### PR TITLE
feat: use latency class with max aggregation for latency-spikes-usec

### DIFF
--- a/hwlatdetect-post-process.py
+++ b/hwlatdetect-post-process.py
@@ -59,7 +59,7 @@ def main():
                     print("ERROR: Failed to determine max latency, something unexpected probably happened!")
                     sys.exit(1)
 
-                desc = {"source": "hwlatdetect", "type": primary_metric, "class": "count"}
+                desc = {"source": "hwlatdetect", "type": primary_metric, "class": "latency", "default-aggregation": "max"}
                 sample = {"begin": times["begin"], "end": times["end"], "value": max_latency}
                 metrics.log_sample("0", desc, {}, sample)
 


### PR DESCRIPTION
## Summary
- Migrate `latency-spikes-usec` from `class=count` to `class=latency` with `default-aggregation=max`
- Max aggregation ensures the highest hardware latency spike across engines is reported, not an average that hides outliers

Part of [PERFNFV-412](https://redhat.atlassian.net/browse/PERFNFV-412) / epic [PERFNFV-409](https://redhat.atlassian.net/browse/PERFNFV-409)

## Test plan
- [ ] Verify metric indexed with `class=latency` and `default-aggregation=max`

🤖 Generated with [Claude Code](https://claude.com/claude-code)